### PR TITLE
Improve pagination documentation.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -183,12 +183,18 @@ All list responses contain the `x-total-count` header which contains the total n
 
 ### Pagination
 
-All lists retrieved are actually pages.  The following query parameters are used in pagination:
+All lists retrieved are actually pages.
+  
+There is no default sort order; when no sort order is specified, the order is undefined.  
+Because of this, and because the server does not save state between network requests,
+pagination across multiple pages will only work correctly when a sort order is specified.
+  
+The following query parameters are used in pagination:
 
 * limit - the maximum number of items to fetch in a single call; defaults to MAX_RESULTS defined in util/types/constants.js, currently 10,000.
 * offset - the number of items to skip before fetching.  0 based.
 
-For instance, `GET /api/v1.1/schemas?limit=3&offset=4` retrieves the schemas at positions 3, 4, and 5.
+For instance, `GET /api/v1.1/schemas?limit=3&offset=4&sort=name` retrieves the schemas at positions 4, 5, and 6 (0 based).
 
 ### Field selection
 


### PR DESCRIPTION
When I execute the example call in the documentation, I don't always get the same results.

Based on my observations, it looks like there is no default sort order, because multiple requests not having a sort order return different results, whereas those containing a sort order always return the same results.

Although this was a surprise to me, it probably shouldn't have been. The server doesn't (can't) save any state between requests, and there is no concept of a result set to be iterated over in multiple requests...right?

So I added some text to clarify this.  Also, I think the numbers in the offset example were off, so I changed them.

Regarding documentation of pagination, clarify that paged responses must have a sort order specified.

Fix position numbers in offset description.
